### PR TITLE
Use WSI compliant actions by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,26 +88,6 @@ $wsdlClient = new PluginClient(
 );
 ```
 
-
-### WSICompliance\QuotedSoapActionMiddleware
-
-Some SOAP engines do not guarantee compatibility with the [WS-I basic profile](http://www.ws-i.org/Profiles/BasicProfile-1.0-2004-04-16.html).
-This middleware ensures that the action inside the SOAPAction header is always wrapped with double quotes [as specified in rule R2744](http://www.ws-i.org/Profiles/BasicProfile-1.0-2004-04-16.html#R2744).
-
-**Usage**
-
-```php
-use Http\Client\Common\PluginClient;
-use Soap\Psr18Transport\Middleware\WSICompliance\QuotedSoapActionMiddleware;
-
-$httpClient = new PluginClient(
-    $psr18Client,
-    [
-        new QuotedSoapActionMiddleware()
-    ]
-);
-```
-
 ### RemoveEmptyNodesMiddleware
 
 Empty properties are converted into empty nodes in the request XML.

--- a/examples/psr18-transport.php
+++ b/examples/psr18-transport.php
@@ -1,0 +1,28 @@
+<?php
+
+use Soap\Engine\SimpleEngine;
+use Soap\ExtSoapEngine\AbusedClient;
+use Soap\ExtSoapEngine\ExtSoapDriver;
+use Soap\ExtSoapEngine\ExtSoapOptions;
+use Soap\ExtSoapEngine\Transport\TraceableTransport;
+use Soap\Psr18Transport\Psr18Transport;
+
+require_once dirname(__DIR__).'/vendor/autoload.php';
+
+$engine = new SimpleEngine(
+    ExtSoapDriver::createFromClient(
+        $client = AbusedClient::createFromOptions(
+            ExtSoapOptions::defaults('http://www.dneonline.com/calculator.asmx?wsdl', [])
+                ->disableWsdlCache()
+        )
+    ),
+    $transport = new TraceableTransport(
+        $client,
+        Psr18Transport::createForClient(new \GuzzleHttp\Client())
+    )
+);
+
+$result = $engine->request('Add', [['intA' => 1, 'intB' => 2]]);
+
+var_dump($result);
+var_dump($transport->collectLastRequestInfo());

--- a/src/HttpBinding/Psr7RequestBuilder.php
+++ b/src/HttpBinding/Psr7RequestBuilder.php
@@ -149,7 +149,7 @@ final class Psr7RequestBuilder
     {
         $headers = [];
         $headers['Content-Length'] = (string) $this->soapMessage?->getSize();
-        $headers['SOAPAction'] = $this->soapAction;
+        $headers['SOAPAction'] = $this->prepareQuotedSoapAction($this->soapAction);
         $headers['Content-Type'] = 'text/xml; charset="utf-8"';
 
         return array_filter($headers);
@@ -169,8 +169,9 @@ final class Psr7RequestBuilder
             return $headers;
         }
 
+        $soapAction = $this->prepareQuotedSoapAction($this->soapAction);
         $headers['Content-Length'] = (string) $this->soapMessage?->getSize();
-        $headers['Content-Type'] = 'application/soap+xml; charset="utf-8"' . '; action="' . $this->soapAction . '"';
+        $headers['Content-Type'] = 'application/soap+xml; charset="utf-8"' . '; action='.$soapAction;
 
         return array_filter($headers);
     }
@@ -182,5 +183,12 @@ final class Psr7RequestBuilder
         }
 
         return $this->streamFactory->createStream('');
+    }
+
+    private function prepareQuotedSoapAction(string $soapAction): string
+    {
+        $soapAction = trim($soapAction, '"\'');
+
+        return '"'.$soapAction.'"';
     }
 }

--- a/src/Middleware/WSICompliance/QuotedSoapActionMiddleware.php
+++ b/src/Middleware/WSICompliance/QuotedSoapActionMiddleware.php
@@ -10,6 +10,8 @@ use Psr\Http\Message\RequestInterface;
 use Soap\Psr18Transport\HttpBinding\SoapActionDetector;
 
 /**
+ * @deprecated The Psr7RequestBuilder now applies this logic automatically. This will be released in v2.x !
+ *
  * @see http://www.ws-i.org/Profiles/BasicProfile-1.0-2004-04-16.html#R2744
  *
  * Fixes error:

--- a/tests/Unit/HttpBinding/Psr7RequestBuilderTest.php
+++ b/tests/Unit/HttpBinding/Psr7RequestBuilderTest.php
@@ -33,11 +33,24 @@ final class Psr7RequestBuilderTest extends TestCase
         static::assertSame('POST', $result->getMethod());
         static::assertSame('text/xml; charset="utf-8"', $result->getHeaderLine('Content-Type'));
         static::assertSame((string) strlen($content), $result->getHeaderLine('Content-Length'));
-        static::assertSame($action, $result->getHeaderLine('SOAPAction'));
+        static::assertSame('"'.$action.'"', $result->getHeaderLine('SOAPAction'));
         static::assertSame($endpoint, $result->getUri()->__toString());
     }
 
-    public function test_it_can_not_use__ge_t_method_with_soap11()
+    public function test_it_can_create_soap11_requests_with_wsi_compliant_empty_action()
+    {
+        $this->builder->isSOAP11();
+        $this->builder->setHttpMethod('POST');
+        $this->builder->setEndpoint($endpoint = 'http://www.endpoint.com');
+        $this->builder->setSoapAction('');
+        $this->builder->setSoapMessage($content = 'content');
+
+        $result = $this->builder->getHttpRequest();
+
+        static::assertSame('""', $result->getHeaderLine('SOAPAction'));
+    }
+
+    public function test_it_can_not_use_get_method_with_soap11()
     {
         $this->builder->isSOAP11();
         $this->builder->setHttpMethod('GET');
@@ -69,7 +82,23 @@ final class Psr7RequestBuilderTest extends TestCase
         static::assertSame($endpoint, $result->getUri()->__toString());
     }
 
-    public function test_it_can_use__ge_t_method_with_soap12()
+    public function test_it_can_create_soap12_requests_with_wsi_compliant_empty_action()
+    {
+        $this->builder->isSOAP12();
+        $this->builder->setHttpMethod('POST');
+        $this->builder->setEndpoint($endpoint = 'http://www.endpoint.com');
+        $this->builder->setSoapAction('');
+        $this->builder->setSoapMessage($content = 'content');
+
+        $result = $this->builder->getHttpRequest();
+
+        static::assertSame(
+            'application/soap+xml; charset="utf-8"; action=""',
+            $result->getHeaderLine('Content-Type')
+        );
+    }
+
+    public function test_it_can_use_get_method_with_soap12()
     {
         $this->builder->isSOAP12();
         $this->builder->setHttpMethod('GET');
@@ -88,7 +117,7 @@ final class Psr7RequestBuilderTest extends TestCase
         static::assertSame('', $result->getBody()->__toString());
     }
 
-    public function test_it_can_not_use__pu_t_method_with_soap12()
+    public function test_it_can_not_use__put_method_with_soap12()
     {
         $this->builder->isSOAP12();
         $this->builder->setHttpMethod('PUT');


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | https://github.com/php-soap/psr18-transport/issues/2

#### Summary

Soap action headers are now quoted by default.
This also happens in ext-soap : https://github.com/php/php-src/blob/1f183792c1cf056fd45c03befbd49a60dec08bb4/ext/soap/php_http.c#L642

The QuotedSoapActionMiddleware is now deprecated, since there should not be any use for it anymore.
