### PR TITLE
Add SOAP header middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,41 @@ $httpClient = new PluginClient(
 );
 ```
 
+### SoapHeaderMiddleware
+
+Attaches multiple SOAP headers to the request before sending the SOAP envelope.
+
+**Usage**
+
+```php
+use Http\Client\Common\PluginClient;
+use Soap\Psr18Transport\Middleware\RemoveEmptyNodesMiddleware;
+use Soap\Xml\Builder\Header\Actor;
+use Soap\Xml\Builder\Header\MustUnderstand;
+use Soap\Xml\Builder\SoapHeader;
+
+
+$httpClient = new PluginClient(
+    $psr18Client,
+    [
+        new SoapHeaderMiddleware(
+            new SoapHeader(
+                $tns,
+                'x:Auth',
+                children(
+                    namespaced_element($tns, 'x:user', value('josbos')),
+                    namespaced_element($tns, 'x:password', value('topsecret'))
+                )
+            ),
+            new SoapHeader($tns, 'Acting', Actor::next()),
+            new SoapHeader($tns, 'Understanding', new MustUnderstand())
+        )
+    ]
+);
+```
+
+More information on the SoapHeader configurator can be found in [php-soap/xml](https://github.com/php-soap/xml#soapheaders).
+
 ### HTTPlug middleware
 
 This package includes [all basic plugins from httplug](https://docs.php-http.org/en/latest/plugins/).

--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,13 @@
         "ext-dom": "*",
         "php-soap/engine": "^1.0",
         "php-soap/wsdl": "^1.0",
-        "php-soap/xml": "^1.0",
+        "php-soap/xml": "^1.3",
         "php-http/discovery": "^1.12",
         "psr/http-client-implementation": "^1.0",
         "psr/http-factory-implementation": "^1.0",
         "psr/http-message-implementation": "^1.0",
         "psr/http-message": "^1.0.1",
-        "veewee/xml": "^1.0",
+        "veewee/xml": "^1.2",
         "php-http/client-common": "^2.3"
     },
     "require-dev": {

--- a/src/Middleware/SoapHeaderMiddleware.php
+++ b/src/Middleware/SoapHeaderMiddleware.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace Soap\Psr18Transport\Middleware;
+
+use DOMElement;
+use DOMNode;
+use Http\Client\Common\Plugin;
+use Http\Promise\Promise;
+use Psr\Http\Message\RequestInterface;
+use Soap\Psr18Transport\Xml\XmlMessageManipulator;
+use Soap\Xml\Builder\SoapHeaders;
+use Soap\Xml\Manipulator\PrependSoapHeaders;
+use VeeWee\Xml\Dom\Document;
+
+final class SoapHeaderMiddleware implements Plugin
+{
+    /**
+     * @var list<callable(DOMNode): DOMElement>
+     */
+    private array $configurators;
+
+    /**
+     * @no-named-arguments
+     * @param list<callable(DOMNode): DOMElement> $configurators
+     */
+    public function __construct(callable ... $configurators)
+    {
+        $this->configurators = $configurators;
+    }
+
+    public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
+    {
+        return $next((new XmlMessageManipulator)(
+            $request,
+            function (Document $document) {
+                /** @var list<DOMElement> $headers */
+                $headers = $document->build(new SoapHeaders(...$this->configurators));
+
+                return $document->manipulate(new PrependSoapHeaders(...$headers));
+            }
+        ));
+    }
+}

--- a/tests/Unit/Middleware/SoapHeaderMiddlewareTest.php
+++ b/tests/Unit/Middleware/SoapHeaderMiddlewareTest.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types=1);
+
+namespace SoapTest\Psr18Transport\Unit\Middleware;
+
+use Http\Client\Common\Plugin;
+use Http\Client\Common\PluginClient;
+use Http\Discovery\Psr17FactoryDiscovery;
+use Http\Mock\Client;
+use Nyholm\Psr7\Request;
+use Nyholm\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Soap\Psr18Transport\Middleware\SoapHeaderMiddleware;
+use Soap\Xml\Builder\Header\Actor;
+use Soap\Xml\Builder\Header\MustUnderstand;
+use Soap\Xml\Builder\SoapHeader;
+use VeeWee\Xml\Dom\Document;
+use function VeeWee\Xml\Dom\Builder\children;
+use function VeeWee\Xml\Dom\Builder\namespaced_element;
+use function VeeWee\Xml\Dom\Builder\value;
+use function VeeWee\Xml\Dom\Configurator\comparable;
+
+final class SoapHeaderMiddlewareTest extends TestCase
+{
+    private PluginClient $client;
+    private Client $mockClient;
+    private SoapHeaderMiddleware $middleware;
+
+    protected function setUp(): void
+    {
+        $tns = 'https://foo.bar';
+        $this->middleware = new SoapHeaderMiddleware(
+            new SoapHeader(
+                $tns,
+                'x:Auth',
+                children(
+                    namespaced_element($tns, 'x:user', value('josbos')),
+                    namespaced_element($tns, 'x:password', value('topsecret'))
+                )
+            ),
+            new SoapHeader($tns, 'Acting', Actor::next()),
+            new SoapHeader($tns, 'Understanding', new MustUnderstand())
+        );
+        $this->mockClient = new Client(Psr17FactoryDiscovery::findResponseFactory());
+        $this->client = new PluginClient($this->mockClient, [$this->middleware]);
+    }
+
+    
+    public function test_it_is_a_middleware()
+    {
+        static::assertInstanceOf(Plugin::class, $this->middleware);
+    }
+
+    public function test_it_appends_soap_headers()
+    {
+        $soapRequest = file_get_contents(FIXTURE_DIR . '/soap/empty-envelope.xml');
+        $this->mockClient->addResponse($response = new Response(200));
+        $this->client->sendRequest($request = new Request('POST', '/', ['SOAPAction' => 'myaction'], $soapRequest));
+
+        $soapBody = (string)$this->mockClient->getRequests()[0]->getBody();
+        $doc = Document::fromXmlString($soapBody, comparable());
+
+        $expected = <<<EOXML
+        <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope/"
+                       soap:encodingStyle="http://www.w3.org/2003/05/soap-encoding">
+            <soap:Header xmlns:soap="http://www.w3.org/2003/05/soap-envelope/">
+                <x:Auth xmlns:x="https://foo.bar">
+                    <x:user>josbos</x:user>
+                    <x:password>topsecret</x:password>
+                </x:Auth>
+                <Acting xmlns="https://foo.bar" soap:actor="http://schemas.xmlsoap.org/soap/actor/next" />
+                <Understanding xmlns="https://foo.bar" soap:mustUnderstand="1" />
+            </soap:Header>
+        </soap:Envelope>
+        EOXML;
+
+        static::assertXmlStringEqualsXmlString(
+            Document::fromXmlString($expected, comparable())->toXmlString(),
+            Document::fromUnsafeDocument($doc->toUnsafeDocument(), comparable())->toXmlString()
+        );
+    }
+}

--- a/tests/fixtures/soap/empty-envelope.xml
+++ b/tests/fixtures/soap/empty-envelope.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope/"
+               soap:encodingStyle="http://www.w3.org/2003/05/soap-encoding">
+</soap:Envelope>


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | https://github.com/php-soap/psr18-transport/issues/3

#### Summary

Middleware that attaches multiple SOAP headers to the request before sending the SOAP envelope.


```php
use Http\Client\Common\PluginClient;
use Soap\Psr18Transport\Middleware\RemoveEmptyNodesMiddleware;
use Soap\Xml\Builder\Header\Actor;
use Soap\Xml\Builder\Header\MustUnderstand;
use Soap\Xml\Builder\SoapHeader;


$httpClient = new PluginClient(
    $psr18Client,
    [
        new SoapHeaderMiddleware(
            new SoapHeader(
                $tns,
                'x:Auth',
                children(
                    namespaced_element($tns, 'x:user', value('josbos')),
                    namespaced_element($tns, 'x:password', value('topsecret'))
                )
            ),
            new SoapHeader($tns, 'Acting', Actor::next()),
            new SoapHeader($tns, 'Understanding', new MustUnderstand())
        )
    ]
);
```
```
