### PR TITLE
Remove content-length - let the client deal with this

### DIFF
--- a/src/HttpBinding/Psr7RequestBuilder.php
+++ b/src/HttpBinding/Psr7RequestBuilder.php
@@ -148,7 +148,6 @@ final class Psr7RequestBuilder
     private function prepareSoap11Headers(): array
     {
         $headers = [];
-        $headers['Content-Length'] = (string) $this->soapMessage?->getSize();
         $headers['SOAPAction'] = $this->prepareQuotedSoapAction($this->soapAction);
         $headers['Content-Type'] = 'text/xml; charset="utf-8"';
 
@@ -170,7 +169,6 @@ final class Psr7RequestBuilder
         }
 
         $soapAction = $this->prepareQuotedSoapAction($this->soapAction);
-        $headers['Content-Length'] = (string) $this->soapMessage?->getSize();
         $headers['Content-Type'] = 'application/soap+xml; charset="utf-8"' . '; action='.$soapAction;
 
         return array_filter($headers);

--- a/src/Xml/Loader/Psr7StreamLoader.php
+++ b/src/Xml/Loader/Psr7StreamLoader.php
@@ -6,6 +6,7 @@ namespace Soap\Psr18Transport\Xml\Loader;
 
 use DOMDocument;
 use Psr\Http\Message\StreamInterface;
+use Soap\Psr18Transport\Exception\RequestException;
 use VeeWee\Xml\Dom\Loader\Loader;
 use function VeeWee\Xml\Dom\Loader\xml_string_loader;
 
@@ -18,9 +19,17 @@ final class Psr7StreamLoader implements Loader
         $this->stream = $stream;
     }
 
+    /**
+     * @throws RequestException
+     */
     public function __invoke(DOMDocument $document): void
     {
         $this->stream->rewind();
-        xml_string_loader((string)$this->stream)($document);
+        $contents = (string) $this->stream;
+        if (!$contents) {
+            throw RequestException::noMessage();
+        }
+
+        xml_string_loader($contents)($document);
     }
 }

--- a/tests/Unit/HttpBinding/Psr7RequestBuilderTest.php
+++ b/tests/Unit/HttpBinding/Psr7RequestBuilderTest.php
@@ -32,7 +32,6 @@ final class Psr7RequestBuilderTest extends TestCase
 
         static::assertSame('POST', $result->getMethod());
         static::assertSame('text/xml; charset="utf-8"', $result->getHeaderLine('Content-Type'));
-        static::assertSame((string) strlen($content), $result->getHeaderLine('Content-Length'));
         static::assertSame('"'.$action.'"', $result->getHeaderLine('SOAPAction'));
         static::assertSame($endpoint, $result->getUri()->__toString());
     }
@@ -77,7 +76,6 @@ final class Psr7RequestBuilderTest extends TestCase
             'application/soap+xml; charset="utf-8"; action="http://www.soapaction.com"',
             $result->getHeaderLine('Content-Type')
         );
-        static::assertSame((string) strlen($content), $result->getHeaderLine('Content-Length'));
         static::assertSame(false, $result->hasHeader('SOAPAction'));
         static::assertSame($endpoint, $result->getUri()->__toString());
     }
@@ -110,7 +108,6 @@ final class Psr7RequestBuilderTest extends TestCase
 
         static::assertSame('GET', $result->getMethod());
         static::assertSame(false, $result->hasHeader('Content-Type'));
-        static::assertSame(false, $result->hasHeader('Content-Length'));
         static::assertSame(false, $result->hasHeader('SOAPAction'));
         static::assertSame('application/soap+xml', $result->getHeaderLine('Accept'));
         static::assertSame($endpoint, $result->getUri()->__toString());


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | Fixes #7 

#### Summary

See #7 and https://github.com/phpro/soap-client/issues/416

The client should not add a Content-Length header, since the content can be changed by plugins.
Let the HTTP client decide the content-length instead.
