### PR TITLE
Strip unwanted quotes from soapAction header

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,5 +41,10 @@
         "php-soap/engine-integration-tests": "^1.4",
         "phpunit/phpunit": "^10.0",
         "guzzlehttp/guzzle": "^7.5"
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
+        }
     }
 }

--- a/src/HttpBinding/SoapActionDetector.php
+++ b/src/HttpBinding/SoapActionDetector.php
@@ -11,9 +11,10 @@ final class SoapActionDetector
 {
     public static function detectFromRequest(RequestInterface $request): string
     {
+        $normalize = static fn (string $action): string => trim($action, '"\'');
         $header = $request->getHeader('SOAPAction');
         if ($header) {
-            return $header[0];
+            return $normalize($header[0]);
         }
 
         $contentTypes = $request->getHeader('Content-Type');
@@ -21,7 +22,7 @@ final class SoapActionDetector
             $contentType = $contentTypes[0];
             foreach (explode(';', $contentType) as $part) {
                 if (strpos($part, 'action=') !== false) {
-                    return trim(explode('=', $part)[1], '"\'');
+                    return $normalize(explode('=', $part)[1]);
                 }
             }
         }

--- a/tests/Unit/HttpBinding/SoapActionTest.php
+++ b/tests/Unit/HttpBinding/SoapActionTest.php
@@ -19,7 +19,14 @@ final class SoapActionTest extends TestCase
         static::assertSame('actionhere', $result);
     }
 
-    
+    public function test_it_strips_out_additional_quotes_from_header_value()
+    {
+        $request = $this->createRequest()->withAddedHeader('SoapAction', '"actionhere"');
+        $result = (new SoapActionDetector())->detectFromRequest($request);
+
+        static::assertSame('actionhere', $result);
+    }
+
     public function test_it_can_detect_soap_action_from_soap_12_content_type_header_with_double_quote()
     {
         $request = $this->createRequest()
@@ -30,7 +37,7 @@ final class SoapActionTest extends TestCase
         static::assertSame('actionhere', $result);
     }
 
-    
+
     public function test_it_can_detect_soap_action_from_soap_12_content_type_header_with_single_quote()
     {
         $request = $this->createRequest()
@@ -40,7 +47,7 @@ final class SoapActionTest extends TestCase
         static::assertSame('actionhere', $result);
     }
 
-    
+
     public function test_it_throws_an_http_request_exception_when_no_header_could_be_found()
     {
         $this->expectException(RequestException::class);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Guzzle returns quotes around the SOAPAction header. this removes them.
