### PR TITLE
Upgrade to veewee/xml v4 and bump minimum PHP to 8.4

### DIFF
--- a/.github/workflows/analyzers.yaml
+++ b/.github/workflows/analyzers.yaml
@@ -7,7 +7,7 @@ jobs:
         strategy:
             matrix:
                 operating-system: [ubuntu-latest]
-                php-versions: [ '8.3', '8.4', '8.5' ]
+                php-versions: [ '8.4', '8.5' ]
                 composer-options: [ '--ignore-platform-req=php+' ]
             fail-fast: false
         name: PHP ${{ matrix.php-versions }} @ ${{ matrix.operating-system }}

--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -7,7 +7,7 @@ jobs:
         strategy:
             matrix:
                 operating-system: [ubuntu-latest]
-                php-versions: [ '8.3', '8.4', '8.5' ]
+                php-versions: [ '8.4', '8.5' ]
                 composer-options: [ '--ignore-platform-req=php+' ]
             fail-fast: false
         name: PHP ${{ matrix.php-versions }} @ ${{ matrix.operating-system }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ jobs:
         strategy:
             matrix:
                 operating-system: [ubuntu-latest]
-                php-versions: [ '8.3', '8.4', '8.5' ]
+                php-versions: [ '8.4', '8.5' ]
                 composer-options: [ '--ignore-platform-req=php+' ]
             fail-fast: false
         name: PHP ${{ matrix.php-versions }} @ ${{ matrix.operating-system }}

--- a/composer.json
+++ b/composer.json
@@ -20,17 +20,17 @@
         }
     ],
     "require": {
-        "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
+        "php": "~8.4.0 || ~8.5.0",
         "ext-dom": "*",
-        "php-soap/engine": "^2.16",
-        "php-soap/wsdl": "^1.14",
-        "php-soap/xml": "^1.9",
+        "php-soap/engine": "^2.19",
+        "php-soap/wsdl": "^1.19",
+        "php-soap/xml": "^1.10",
         "php-http/discovery": "^1.12",
         "psr/http-client-implementation": "^1.0",
         "psr/http-factory-implementation": "^1.0",
         "psr/http-message-implementation": "^1.0",
         "psr/http-message": "^1.0.1|^2.0",
-        "veewee/xml": "^3.0",
+        "veewee/xml": "^4.9",
         "php-http/client-common": "^2.3"
     },
     "require-dev": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -3,7 +3,7 @@
     errorLevel="1"
     resolveFromConfigFile="true"
     strictBinaryOperands="true"
-    phpVersion="8.3"
+    phpVersion="8.4"
     allowStringToStandInForClass="true"
     rememberPropertyAssignmentsAfterCall="false"
     skipChecksOnUnresolvableIncludes="false"
@@ -13,6 +13,9 @@
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
 >
+    <stubs>
+        <file name="vendor/veewee/xml/stubs/DOM.phpstub" />
+    </stubs>
     <projectFiles>
         <directory name="src" />
         <ignoreFiles>

--- a/src/Middleware/RemoveEmptyNodesMiddleware.php
+++ b/src/Middleware/RemoveEmptyNodesMiddleware.php
@@ -2,7 +2,7 @@
 
 namespace Soap\Psr18Transport\Middleware;
 
-use DOMNode;
+use Dom\Node;
 use Http\Client\Common\Plugin;
 use Http\Promise\Promise;
 use Psr\Http\Message\RequestInterface;
@@ -23,7 +23,7 @@ final class RemoveEmptyNodesMiddleware implements Plugin
                 do {
                     $emptyNodes = $xpath->query('//soap:Envelope/*//*[not(node())]');
                     $emptyNodes->forEach(
-                        static fn (DOMNode $element) => remove($element)
+                        static fn (Node $element) => remove($element)
                     );
                 } while ($emptyNodes->count());
             }

--- a/src/Middleware/SoapHeaderMiddleware.php
+++ b/src/Middleware/SoapHeaderMiddleware.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Soap\Psr18Transport\Middleware;
 
-use DOMElement;
-use DOMNode;
+use Dom\Element;
+use Dom\Node;
 use Http\Client\Common\Plugin;
 use Http\Promise\Promise;
 use Psr\Http\Message\RequestInterface;
@@ -16,13 +16,13 @@ use VeeWee\Xml\Dom\Document;
 final class SoapHeaderMiddleware implements Plugin
 {
     /**
-     * @var list<callable(DOMNode): DOMElement>
+     * @var list<callable(Node): Element>
      */
     private array $configurators;
 
     /**
      * @no-named-arguments
-     * @param list<callable(DOMNode): DOMElement> $configurators
+     * @param list<callable(Node): Element> $configurators
      */
     public function __construct(callable ... $configurators)
     {
@@ -34,7 +34,7 @@ final class SoapHeaderMiddleware implements Plugin
         return $next((new XmlMessageManipulator)(
             $request,
             function (Document $document) {
-                /** @var list<DOMElement> $headers */
+                /** @var list<Element> $headers */
                 $headers = $document->build(new SoapHeaders(...$this->configurators));
 
                 return $document->manipulate(new PrependSoapHeaders(...$headers));

--- a/src/Middleware/Wsdl/DisableExtensionsMiddleware.php
+++ b/src/Middleware/Wsdl/DisableExtensionsMiddleware.php
@@ -2,7 +2,7 @@
 
 namespace Soap\Psr18Transport\Middleware\Wsdl;
 
-use DOMElement;
+use Dom\Element;
 use Http\Client\Common\Plugin;
 use Http\Promise\Promise;
 use Psr\Http\Message\RequestInterface;
@@ -31,9 +31,9 @@ final class DisableExtensionsMiddleware implements Plugin
         $namespace = $document->locate(root_namespace_uri());
         $document->xpath(new WsdlPreset($document))
             ->query('//wsdl:binding//*[@wsdl:required]')
-            ->expectAllOfType(DOMElement::class)
+            ->expectAllOfType(Element::class)
             ->forEach(
-                static function (DOMElement $element) use ($namespace): void {
+                static function (Element $element) use ($namespace): void {
                     namespaced_attribute($namespace ?? '', 'wsdl:required', 'false')($element);
                 }
             );

--- a/src/Middleware/Wsdl/DisablePoliciesMiddleware.php
+++ b/src/Middleware/Wsdl/DisablePoliciesMiddleware.php
@@ -2,7 +2,7 @@
 
 namespace Soap\Psr18Transport\Middleware\Wsdl;
 
-use DOMElement;
+use Dom\Element;
 use Http\Client\Common\Plugin;
 use Http\Promise\Promise;
 use Psr\Http\Message\RequestInterface;
@@ -35,18 +35,18 @@ final class DisablePoliciesMiddleware implements Plugin
 
         // remove all "UsingPolicy" tags
         $xpath->query('//wsd:UsingPolicy')
-            ->expectAllOfType(DOMElement::class)
+            ->expectAllOfType(Element::class)
             ->forEach(
-                static function (DOMElement $element): void {
+                static function (Element $element): void {
                     remove($element);
                 }
             );
 
         // remove all "Policy" tags
         $xpath->query('//wsd:Policy')
-            ->expectAllOfType(DOMElement::class)
+            ->expectAllOfType(Element::class)
             ->forEach(
-                static function (DOMElement $element): void {
+                static function (Element $element): void {
                     remove($element);
                 }
             );

--- a/src/Xml/Loader/Psr7StreamLoader.php
+++ b/src/Xml/Loader/Psr7StreamLoader.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Soap\Psr18Transport\Xml\Loader;
 
-use DOMDocument;
+use Dom\XMLDocument;
 use Psr\Http\Message\StreamInterface;
 use Soap\Psr18Transport\Exception\RequestException;
 use VeeWee\Xml\Dom\Loader\Loader;
@@ -22,7 +22,7 @@ final class Psr7StreamLoader implements Loader
     /**
      * @throws RequestException
      */
-    public function __invoke(DOMDocument $document): void
+    public function __invoke(): XMLDocument
     {
         $this->stream->rewind();
         $contents = (string) $this->stream;
@@ -30,6 +30,6 @@ final class Psr7StreamLoader implements Loader
             throw RequestException::noMessage();
         }
 
-        xml_string_loader($contents)($document);
+        return xml_string_loader($contents)();
     }
 }

--- a/src/Xml/Mapper/Psr7StreamMapper.php
+++ b/src/Xml/Mapper/Psr7StreamMapper.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Soap\Psr18Transport\Xml\Mapper;
 
-use DOMDocument;
+use Dom\XMLDocument;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Psr\Http\Message\StreamInterface;
 use VeeWee\Xml\Dom\Mapper\Mapper;
@@ -14,7 +14,7 @@ use VeeWee\Xml\Dom\Mapper\Mapper;
  */
 final class Psr7StreamMapper implements Mapper
 {
-    public function __invoke(DOMDocument $document): StreamInterface
+    public function __invoke(XMLDocument $document): StreamInterface
     {
         $factory = Psr17FactoryDiscovery::findStreamFactory();
         $stream = $factory->createStream($document->saveXML());

--- a/src/Xml/XmlMessageManipulator.php
+++ b/src/Xml/XmlMessageManipulator.php
@@ -8,7 +8,6 @@ use Psr\Http\Message\MessageInterface;
 use Soap\Psr18Transport\Xml\Loader\Psr7StreamLoader;
 use Soap\Psr18Transport\Xml\Mapper\Psr7StreamMapper;
 use VeeWee\Xml\Dom\Document;
-use function VeeWee\Xml\Dom\Configurator\loader;
 
 final class XmlMessageManipulator
 {
@@ -20,7 +19,7 @@ final class XmlMessageManipulator
      */
     public function __invoke(MessageInterface $message, callable $manipulator): MessageInterface
     {
-        $document = Document::configure(loader(new Psr7StreamLoader($message->getBody())));
+        $document = Document::fromLoader(new Psr7StreamLoader($message->getBody()));
         $manipulator($document);
 
         return $message->withBody($document->map(new Psr7StreamMapper()));

--- a/tests/Unit/Xml/XmlMessageManipulatorTest.php
+++ b/tests/Unit/Xml/XmlMessageManipulatorTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace SoapTest\Psr18Transport\Xml;
 
-use DOMDocument;
+use Dom\XMLDocument;
 use Http\Discovery\Psr17FactoryDiscovery;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -19,7 +19,7 @@ final class XmlMessageManipulatorTest extends TestCase
         $message = Psr17FactoryDiscovery::findResponseFactory()->createResponse()->withBody($stream);
 
         $manipulated = (new XmlMessageManipulator)($message, static function (Document $doc): void {
-            $doc->manipulate(static function (DOMDocument $dom) {
+            $doc->manipulate(static function (XMLDocument $dom) {
                 $dom->documentElement->setAttribute('name', 'world');
             });
         });


### PR DESCRIPTION
## Summary

- Bumps `veewee/xml` from `^3.0` to `^4.9` (uses PHP 8.4's new spec-compliant `Dom\` API)
- Drops PHP 8.3 support; minimum is now `~8.4.0 || ~8.5.0`
- Removes PHP 8.3 from all GitHub Actions matrices
- Updates Psalm `phpVersion` to `8.4` and adds DOM stubs from `veewee/xml` 4.8+

## Migration changes

- `Psr7StreamLoader`: updated to new `Loader` interface (`__invoke(): XMLDocument` instead of mutating a passed `DOMDocument`)
- `Psr7StreamMapper`: updated to new `Mapper` interface (parameter is now `Dom\XMLDocument`)
- `XmlMessageManipulator`: replaced `Document::configure(loader(...))` with `Document::fromLoader(...)`
- All `DOMDocument` / `DOMElement` / `DOMNode` type hints replaced with `Dom\XMLDocument` / `Dom\Element` / `Dom\Node`
- All `expectAllOfType(DOMElement::class)` calls updated to `expectAllOfType(Element::class)`

## Test plan

- [ ] PHPUnit passes locally (31 tests, 51 assertions)
- [ ] Psalm passes with no errors, 100% type coverage
- [ ] php-cs-fixer reports 0 fixable files
- [ ] All tests pass in Docker (`docphpro/php84` — PHP 8.4.19, libxml 2.9.14 on Ubuntu 24.04)