### PR TITLE
[1.x] Backport PromoteNamespacesMiddleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,37 @@ $httpClient = new PluginClient(
 );
 ```
 
+### PromoteNamespacesMiddleware
+
+The [`php-soap/encoding`](https://github.com/php-soap/encoding) package
+encodes and decodes SOAP payloads isomorphically: every encoded element
+declares its own `xmlns:*` prefixes locally, so the same fragment produces
+the same XML whether it lives at the root of a document or deep inside
+another element. That is valid XML, but some SOAP servers enforce via XSD
+that all namespaces are declared on the envelope itself and reject payloads
+with descendant-level declarations (e.g. Microsoft Business Central).
+
+Plug this middleware in between the encoder and the wire to rewrite the
+outgoing request so that every prefixed `xmlns:*` declaration found on a
+descendant is hoisted to the envelope, keeping the original prefix names
+intact. Default namespaces (`xmlns="..."`) and prefixes that conflict with
+a declaration already on the envelope are left untouched.
+
+**Usage**
+
+```php
+use Http\Client\Common\PluginClient;
+use Soap\Psr18Transport\Middleware\PromoteNamespacesMiddleware;
+
+
+$httpClient = new PluginClient(
+    $psr18Client,
+    [
+        new PromoteNamespacesMiddleware()
+    ]
+);
+```
+
 ### SoapHeaderMiddleware
 
 Attaches multiple SOAP headers to the request before sending the SOAP envelope.

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "psr/http-factory-implementation": "^1.0",
         "psr/http-message-implementation": "^1.0",
         "psr/http-message": "^1.0.1|^2.0",
-        "veewee/xml": "^3.0",
+        "veewee/xml": "^3.7",
         "php-http/client-common": "^2.3"
     },
     "require-dev": {

--- a/src/Middleware/PromoteNamespacesMiddleware.php
+++ b/src/Middleware/PromoteNamespacesMiddleware.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Soap\Psr18Transport\Middleware;
+
+use Http\Client\Common\Plugin;
+use Http\Promise\Promise;
+use Psr\Http\Message\RequestInterface;
+use Soap\Psr18Transport\Xml\XmlMessageManipulator;
+use VeeWee\Xml\Dom\Document;
+use function VeeWee\Xml\Dom\Manipulator\Document\promote_namespaces;
+
+final class PromoteNamespacesMiddleware implements Plugin
+{
+    public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
+    {
+        $request = (new XmlMessageManipulator())(
+            $request,
+            static function (Document $document): void {
+                promote_namespaces($document->toUnsafeDocument());
+            }
+        );
+
+        return $next($request);
+    }
+}

--- a/tests/Unit/Middleware/PromoteNamespacesMiddlewareTest.php
+++ b/tests/Unit/Middleware/PromoteNamespacesMiddlewareTest.php
@@ -1,0 +1,109 @@
+<?php declare(strict_types=1);
+
+namespace SoapTest\Psr18Transport\Unit\Middleware;
+
+use Http\Client\Common\Plugin;
+use Http\Client\Common\PluginClient;
+use Http\Discovery\Psr17FactoryDiscovery;
+use Http\Mock\Client;
+use Nyholm\Psr7\Request;
+use Nyholm\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Soap\Psr18Transport\Middleware\PromoteNamespacesMiddleware;
+use Soap\Xml\Xpath\EnvelopePreset;
+use VeeWee\Xml\Dom\Document;
+use VeeWee\Xml\Dom\Xpath;
+use function VeeWee\Xml\Dom\Locator\document_element;
+
+final class PromoteNamespacesMiddlewareTest extends TestCase
+{
+    private const XMLNS = 'http://www.w3.org/2000/xmlns/';
+
+    private PluginClient $client;
+    private Client $mockClient;
+    private PromoteNamespacesMiddleware $middleware;
+
+    protected function setUp(): void
+    {
+        $this->middleware = new PromoteNamespacesMiddleware();
+        $this->mockClient = new Client(Psr17FactoryDiscovery::findResponseFactory());
+        $this->client = new PluginClient($this->mockClient, [$this->middleware]);
+    }
+
+    public function test_it_is_a_middleware(): void
+    {
+        static::assertInstanceOf(Plugin::class, $this->middleware);
+    }
+
+    public function test_it_promotes_descendant_namespaces_to_envelope(): void
+    {
+        $soapRequest = file_get_contents(FIXTURE_DIR . '/soap/with-descendant-namespaces-request.xml');
+        $this->mockClient->addResponse(new Response(200));
+        $this->client->sendRequest(new Request('POST', '/', ['SOAPAction' => 'myaction'], $soapRequest));
+
+        $soapBody = (string) $this->mockClient->getRequests()[0]->getBody();
+        $document = Document::fromXmlString($soapBody);
+        $envelope = $document->map(document_element());
+
+        static::assertSame(
+            'https://example.com',
+            $envelope->getAttributeNS(self::XMLNS, 'tns'),
+            'xmlns:tns must be declared on the envelope element itself'
+        );
+        static::assertSame(
+            'http://www.w3.org/2001/XMLSchema-instance',
+            $envelope->getAttributeNS(self::XMLNS, 'xsi'),
+            'xmlns:xsi must be declared on the envelope element itself'
+        );
+        static::assertSame(
+            'http://www.w3.org/2001/XMLSchema',
+            $envelope->getAttributeNS(self::XMLNS, 'xsd'),
+            'xmlns:xsd must be declared on the envelope element itself'
+        );
+
+        $xpath = $this->fetchEnvelopeXpath($document);
+        static::assertSame(
+            0,
+            $xpath->query('//soap-env:Envelope/descendant::*/@*[namespace-uri()="' . self::XMLNS . '"]')->count(),
+            'no descendant element must carry its own xmlns:* declaration'
+        );
+
+        static::assertSame(1, $xpath->query('//soap-env:Body/tns:GetUser/tns:Id')->count());
+        static::assertSame('1', (string) $xpath->query('//soap-env:Body/tns:GetUser/tns:Id')->item(0)->textContent);
+    }
+
+    public function test_it_leaves_default_namespace_in_place(): void
+    {
+        $soapRequest = <<<'EOXML'
+        <?xml version="1.0" encoding="UTF-8"?>
+        <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+            <SOAP-ENV:Body>
+                <Payload xmlns="https://example.com/default"><Inner/></Payload>
+            </SOAP-ENV:Body>
+        </SOAP-ENV:Envelope>
+        EOXML;
+
+        $this->mockClient->addResponse(new Response(200));
+        $this->client->sendRequest(new Request('POST', '/', [], $soapRequest));
+
+        $document = Document::fromXmlString((string) $this->mockClient->getRequests()[0]->getBody());
+        $envelope = $document->map(document_element());
+        $payload = $envelope->getElementsByTagName('Payload')->item(0);
+
+        static::assertNotNull($payload);
+        static::assertSame('https://example.com/default', $payload->namespaceURI);
+        static::assertTrue($payload->hasAttribute('xmlns'), 'default xmlns must remain on the Payload element');
+        static::assertFalse($envelope->hasAttribute('xmlns'), 'default xmlns must not leak onto the envelope');
+    }
+
+    private function fetchEnvelopeXpath(Document $document): Xpath
+    {
+        return $document->xpath(
+            new EnvelopePreset($document),
+            \VeeWee\Xml\Dom\Xpath\Configurator\namespaces([
+                'tns' => 'https://example.com',
+                'soap-env' => 'http://schemas.xmlsoap.org/soap/envelope/',
+            ])
+        );
+    }
+}

--- a/tests/fixtures/soap/with-descendant-namespaces-request.xml
+++ b/tests/fixtures/soap/with-descendant-namespaces-request.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Body>
+        <tns:GetUser xmlns:tns="https://example.com">
+            <tns:Id xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:type="xsd:int">1</tns:Id>
+        </tns:GetUser>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>


### PR DESCRIPTION
## Summary

Backport of #23 to the 1.x branch for projects still on PHP 8.3 / veewee/xml 3.x.

The middleware source is identical to the 2.x version — \`promote_namespaces\` has the same signature on both veewee/xml 3.x (legacy \`DOMDocument\`) and 4.x (\`Dom\XMLDocument\`), and \`Document::toUnsafeDocument()\` hands back whichever one matches the installed major.

## Motivation

The \`php-soap/encoding\` package encodes and decodes SOAP payloads isomorphically: every encoded element declares its own \`xmlns:*\` prefixes locally. That is valid XML, but some SOAP servers enforce via XSD that all namespaces are declared on the envelope itself and reject payloads with descendant-level declarations (e.g. Microsoft Business Central). This middleware rewrites outgoing requests to satisfy those servers without touching the encoder.

Refs php-soap/encoding#48.

## Dependency

Bumps \`veewee/xml\` to \`^3.7\` — see [veewee/xml 3.7.0](https://github.com/veewee/xml/releases/tag/3.7.0), which contains the \`promote_namespaces\` manipulator.

## Test plan

- [x] \`vendor/bin/phpunit\` — 34 pass, 62 assertions
- [x] \`vendor/bin/psalm\` — 100%, no errors
- [x] \`vendor/bin/php-cs-fixer fix --dry-run\` — clean